### PR TITLE
Added perl 5.30 and 5.32 removed perl 5.26 from test

### DIFF
--- a/.github/workflows/fhem_test.yml
+++ b/.github/workflows/fhem_test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        perl: [ '5.22', '5.26', '5.28' ]
+        perl: [ '5.22', '5.28', '5.30', '5.32' ]
 
     name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
     steps:


### PR DESCRIPTION
This change adds Perl 5.30 and 5.32 to the test suite, because 5.30 and 5.32 has some changes.

Removed 5.26 because there is nothing specal in there. Test of 5.22 and 5.28 is still there