### PR TITLE
Only push workflow updates after commit

### DIFF
--- a/.github/workflows/fhem_test.yml
+++ b/.github/workflows/fhem_test.yml
@@ -34,12 +34,19 @@ jobs:
         LOG+=" - $(git log -1 --pretty=%B)"
         echo "$LOG" | cat - CHANGED  2>/dev/null >> temp || true  && mv temp CHANGED
     - name: git commit back
+      id: git_commit_back
       run: |
         git config --global user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add  CHANGED ${{env.CONTROLS_FILENAME}}  || true
-        git log -1 --name-only --pretty=format: | grep -Eo '[0-9]{2}_.*.pm$' && git commit CHANGED ${{env.CONTROLS_FILENAME}}  -m "Automaitc updated controls and CHANGED" || true
+        if git log -1 --name-only --pretty=format: | grep -Eo '[0-9]{2}_.*.pm$' && ! git diff --cached --quiet; then
+          git commit CHANGED ${{env.CONTROLS_FILENAME}} -m "Automaitc updated controls and CHANGED"
+          echo "committed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "committed=false" >> "$GITHUB_OUTPUT"
+        fi
     - name: git push
+      if: steps.git_commit_back.outputs.committed == 'true'
       uses: ad-m/github-push-action@v1.0.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- record whether the workflow update step actually created a commit
- run the repository push action only when that commit exists

## Motivation

The previous workflow always ran the push step, even when the commit step did not create a commit. In environments where the workflow actor does not have push permissions, that caused the pipeline to fail unnecessarily.

## Validation

- parsed `.github/workflows/fhem_test.yml` with Python YAML loader